### PR TITLE
Use `exec` instead of `run`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,10 @@ jobs:
           rm -rf ${{ env.CACHE_OLD }}
           mv ${{ env.CACHE_NEW }} ${{ env.CACHE_OLD }}
 
+      - name: Starts all docker services
+        run: |
+          ./run dc:up
+
       # ---------------------------------------------- #
       #                     NodeJS                     #
       # ---------------------------------------------- #
@@ -73,7 +77,7 @@ jobs:
       - name: Install node modules
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: |
-          ./run dc:run bash -c "npm ci --quiet && touch node_modules/.gitkeep"
+          ./run dc:exec bash -c "npm ci --quiet && touch node_modules/.gitkeep"
 
       # ---------------------------------------------- #
       #                     Elixir                     #
@@ -93,17 +97,17 @@ jobs:
       - name: Install Elixir dependencies
         if: steps.elixir-cache.outputs.cache-hit != 'true'
         run: |
-          ./run dc:run mix deps.get
+          ./run dc:exec mix deps.get
 
       - name: Compile Elixir application (dev)
         if: steps.elixir-cache.outputs.cache-hit != 'true'
         run: |
-          ./run dc:run mix compile
+          ./run dc:exec mix compile
 
       - name: Compile Elixir application (test)
         if: steps.elixir-cache.outputs.cache-hit != 'true'
         run: |
-          ./run dc:run bash -c "MIX_ENV=test mix compile"
+          ./run dc:exec bash -c "MIX_ENV=test mix compile"
 
       # ---------------------------------------------- #
       #                   Application                  #
@@ -111,8 +115,8 @@ jobs:
 
       - name: Test
         run: |
-          ./run dc:run ./run test
+          ./run dc:exec ./run test
 
       - name: Lint
         run: |
-          ./run dc:run ./run lint
+          ./run dc:exec ./run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# shellcheck source=.husky/_/husky.sh
 . "$(dirname "$0")/_/husky.sh"
+
+if [ "${INSIDE_DOCKER:-0}" -ne 1 ]; then
+  ./run dc:build
+fi
 
 ./run pre-commit

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,11 +47,25 @@
       "detail": "Build all docker services"
     },
     {
+      "label": "dc:exec",
+      "type": "shell",
+      "command": "./run dc:exec",
+      "problemMatcher": [],
+      "detail": "Execute a command in a 'app' docker service"
+    },
+    {
       "label": "dc:run",
       "type": "shell",
       "command": "./run dc:run ${input:cmd}",
       "problemMatcher": [],
       "detail": "Run a command inside the 'app' docker service and remove stopped containers"
+    },
+    {
+      "label": "dc:up",
+      "type": "shell",
+      "command": "./run dc:up",
+      "problemMatcher": [],
+      "detail": "Starts all docker services"
     },
     /* -------------------------------------------- */
     /*                      Dev                     */

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,4 +5,3 @@ services:
     image: aifrak/template-elixir:dev
     build:
       target: dev
-    command: sleep infinity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
         USER_UID: ${USER_UID:-1000}
         USER_GID: ${USER_GID:-1000}
     user: ${USER_UID:-1000}:${USER_GID:-1000}
+    command: sleep infinity
     volumes:
       - .:/app

--- a/run
+++ b/run
@@ -11,7 +11,7 @@ set -euo pipefail
 # commands that enable it by default, such as exec and run.
 # Idea from: https://github.com/nickjj/docker-flask-example/blob/main/run
 TTY=""
-if [[ ! -t 1 ]]; then
+if [[ ! -t 1 ]] || [[ ${CI:-false} = true ]]; then
   TTY="-T"
 fi
 
@@ -31,7 +31,9 @@ Main commands:
 
 docker-compose commands:
   dc:build                   Build all docker services
+  dc:exec                    Execute a command in a "app" docker service
   dc:run                     Run a command inside the "app" docker service and remove stopped containers
+  dc:up                      Starts all docker services
 
 Dev commands:
   dev:code                   Prepare docker services for development environment
@@ -66,7 +68,7 @@ function test {
   if is_inside_docker; then
     elixir:test
   else
-    dc:run ./run test
+    dc:exec ./run test
   fi
 }
 
@@ -88,7 +90,7 @@ function lint {
       exit ${status}
     fi
   else
-    dc:run ./run lint
+    dc:exec ./run lint
   fi
 }
 
@@ -102,7 +104,7 @@ function format {
 
     success "✔ Project formatted"
   else
-    dc:run ./run format
+    dc:exec ./run format
   fi
 }
 
@@ -112,7 +114,7 @@ function pre-commit {
     lint
     test
   else
-    dc:run ./run pre-commit
+    dc:exec ./run pre-commit
   fi
 }
 
@@ -124,9 +126,17 @@ function dc:build {
   docker buildx bake
 }
 
+function dc:exec {
+  docker-compose exec ${TTY} app "${@}"
+}
+
 function dc:run {
   docker-compose run ${TTY} app "${@}"
   docker-compose rm -f -v
+}
+
+function dc:up {
+  docker-compose up -d --remove-orphans
 }
 
 # ---------------------------------------------- #


### PR DESCRIPTION
- `sleep infinity` for base `app` service
- Add `-T` to `exec` and `run` when executing from `CI`
- Build docker image before `pre-commit` checks
- Lint `pre-commit` file
- Start services after docker image is built
- Add `dc:build` and `dc:up` in `help()` and `tasks`