### PR TITLE
Force `test` env for `credo`

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -4,7 +4,8 @@
       name: "default",
       files: %{
         included: ["lib/", "test/", "mix.exs", ".credo.exs", ".formatter.exs"],
-        excluded: []
+        # HACK: Exclude mix.exs because of bug from https://github.com/rrrene/credo/issues/873
+        excluded: ["mix.exs"]
       },
       strict: true,
       checks: [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,11 +108,6 @@ jobs:
         run: |
           ./run dc:exec mix deps.get
 
-      - name: Compile Elixir application (dev)
-        if: steps.elixir-cache.outputs.cache-hit != 'true'
-        run: |
-          ./run dc:exec mix compile
-
       - name: Compile Elixir application (test)
         if: steps.elixir-cache.outputs.cache-hit != 'true'
         run: |

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,10 @@ defmodule App.MixProject do
       version: "0.1.0",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      preferred_cli_env: [
+        credo: :test
+      ]
     ]
   end
 
@@ -19,7 +22,7 @@ defmodule App.MixProject do
 
   defp deps do
     [
-      {:credo, "~> 1.5", only: [:dev, :test], runtime: false}
+      {:credo, "~> 1.5", only: [:test], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
- ci: no `mix compile` for `dev` env
- Exclude `mix.exs` from `credo` because of known bug