### PR TITLE
build(mix): Run format commands concurrently

### DIFF
--- a/.check-format.exs
+++ b/.check-format.exs
@@ -1,0 +1,13 @@
+# Override default config from .check.exs
+[
+  tools: [
+    # Custom tools
+    {:css_format, "./run css:format"},
+    {:dockerfile_format, "./run dockerfile:format"},
+    {:elixir_format, "./run elixir:format"},
+    {:elixir_eex_format, "./run elixir:eex:format", deps: [:css_format, :js_format]},
+    {:js_format, "./run js:format"},
+    {:prettier_format, "./run prettier:format", deps: [:css_format, :js_format]},
+    {:shell_format, "./run shell:format"}
+  ]
+]

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -21,6 +21,7 @@ rules:
       - git
       - lint
       - logs
+      - mix
       - npm
       - license
       - readme

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule App.MixProject do
       {:credo_naming, ">= 1.0.0", only: :test, runtime: false},
       {:dialyxir, ">= 1.1.0", only: :test, runtime: false},
       {:doctor, ">= 0.18.0", only: :test, runtime: false},
-      {:ex_check, ">= 0.14.0", only: :test, runtime: false},
+      {:ex_check, ">= 0.14.0", only: [:dev, :test], runtime: false},
       {:excoveralls, ">= 0.14.2", only: :test, runtime: false},
       {:sobelow, ">= 0.11.1", only: :test, runtime: false}
     ]
@@ -38,6 +38,17 @@ defmodule App.MixProject do
     [
       check: ["check --config .check-dev.exs"],
       "check.ci": ["check --config .check-ci.exs"],
+      "format.all": [
+        "check --config .check-format.exs \
+          --only css_format \
+          --only dockerfile_format \
+          --only elixir_format \
+          --only elixir_eex_format \
+          --only js_format \
+          --only prettier_format \
+          --only shell_format \
+        "
+      ],
       "npm.dev": ["cmd npm install --quiet"],
       "npm.ci": ["cmd npm ci --quiet"],
       setup: ["deps.unlock --unused", "deps.clean --unused", "deps.get"],
@@ -52,7 +63,6 @@ defmodule App.MixProject do
 
   defp preferred_cli_env do
     [
-      check: :test,
       "check.ci": :test,
       compile: :test,
       credo: :test,
@@ -63,6 +73,7 @@ defmodule App.MixProject do
       dialyxir: :test,
       dialyzer: :test,
       doctor: :test,
+      "format.all": :dev,
       "test.cover": :test,
       "test.cover.recent": :test,
       sobelow: :test,

--- a/run
+++ b/run
@@ -114,15 +114,7 @@ function lint {
 function format {
   # shellcheck disable=SC2119
   if is_inside_docker; then
-    css:format
-    elixir:eex:format
-    elixir:format
-    js:format
-    shell:format
-    dockerfile:format
-    prettier:format
-
-    success "✔ Project formatted"
+    mix format.all
   else
     dc:exec ./run format
   fi


### PR DESCRIPTION
Additional changes:
- Add new mix alias `format.all`
- `ex-check` with `dev` and `test` environment
- Add `mix` as commitlint scope