### PR TITLE
ci: Cache `dialyzer` PLTs separately

### DIFF
--- a/.check.exs
+++ b/.check.exs
@@ -4,6 +4,7 @@
   retry: false,
   tools: [
     # Extends curated tools from ex_check
+    {:dialyzer, "mix dialyzer --format short", detect: [{:package, :dialyxir}]},
     {
       :doctor,
       "mix doctor --summary",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,23 @@ jobs:
         with:
           path: |
             **/_build
-            **/priv/plts/*.plt
-            **/priv/plts/*.plt.hash
             **/.sobelow
           key: |
             ${{ runner.os }}-elixir-build-${{ env.ELIXIR_VERSION }}-${{ env.ERLANG_VERSION }}-${{ hashFiles('**/mix.lock') }}-${{ hashFiles( '**/lib/**/*.{ex,eex}', '**/config/*.exs', '**/mix.exs' ) }}
           restore-keys: |
             ${{ runner.os }}-elixir-build-${{ env.ELIXIR_VERSION }}-${{ env.ERLANG_VERSION }}-${{ hashFiles('**/mix.lock') }}-
             ${{ runner.os }}-elixir-build-${{ env.ELIXIR_VERSION }}-${{ env.ERLANG_VERSION }}-
+
+      - name: Cache Dialyzer PLTs
+        id: dialyzer-plts-cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: |
+            **/priv/plts
+          key: |
+            ${{ runner.os }}-dialyzer-plts-${{ env.ELIXIR_VERSION }}-${{ env.ERLANG_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-dialyzer-plts-${{ env.ELIXIR_VERSION }}-${{ env.ERLANG_VERSION }}
 
       - name: Cache node modules
         uses: actions/cache@v2.1.7

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ config/*.secret.exs
 .elixir_ls/
 
 # Dialyzer
-**/priv/plts/*.plt
-**/priv/plts/*.plt.hash
+**/priv/plts/
 
 # Sobelow
 .sobelow

--- a/mix.exs
+++ b/mix.exs
@@ -95,7 +95,7 @@ defmodule App.MixProject do
         :mix
       ],
       plt_add_deps: :apps_direct,
-      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+      plt_local_path: "priv/plts"
     ]
   end
 


### PR DESCRIPTION
- Replace deprecated `plt_file` with `plt_local_path`
- Compact `dialyzer` warnings