### PR TITLE
chore(lint): Check given files instead of whole project while running `lint-staged`

### DIFF
--- a/.check-ci.exs
+++ b/.check-ci.exs
@@ -10,6 +10,7 @@
         {:file, "codecov.yml", else: :skip}
       ],
       retry: "mix coveralls.json --failed"
-    }
+    },
+    {:lint_staged, false}
   ]
 ]

--- a/.check.exs
+++ b/.check.exs
@@ -3,7 +3,10 @@
 [
   retry: false,
   tools: [
-    # Extends curated tools from ex_check
+    # —————————————————————————————————————————————— #
+    #       Extends curated tools from ex_check      #
+    # —————————————————————————————————————————————— #
+    {:credo, "./run elixir:credo", detect: [{:package, :credo}]},
     {:dialyzer, "mix dialyzer --format short", detect: [{:package, :dialyxir}]},
     {
       :doctor,
@@ -13,6 +16,8 @@
         {:elixir, ">= 1.8.0"}
       ]
     },
+    {:formatter, "./run elixir:format:lint",
+     detect: [{:file, ".formatter.exs"}], fix: "./run elixir:format"},
     {:npm_test, false},
     {
       :sobelow,
@@ -23,8 +28,9 @@
         {:package, :phoenix, else: :skip}
       ]
     },
-
-    # Custom tools
+    # —————————————————————————————————————————————— #
+    #                  Custom tools                  #
+    # —————————————————————————————————————————————— #
     {:css_lint, "./run css:lint"},
     {:dockerfile_lint, "./run dockerfile:lint"},
     {:elixir_eex_lint, "./run elixir:eex:lint"},

--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -2,7 +2,13 @@
   - ./run spellcheck:lint
 
 "*.{ex,exs}":
-  - ./run elixir:lint
+  - ./run elixir:credo
+  - ./run elixir:format:lint
+
+# HACK: "fake1" is a workaround to run different Elixir checks in parallel
+# https://github.com/okonet/lint-staged/issues/934#issuecomment-743299357
+"*.{ex,exs,fake1}":
+  - ./run elixir:lint:light
 
 "*.{css,less,sass,scss}":
   - ./run css:lint

--- a/scripts/run/elixir.sh
+++ b/scripts/run/elixir.sh
@@ -4,8 +4,11 @@ function elixir:help {
   cat <<EOF
 
 Elixir commands:
+  elixir:credo                Perform checks with Credo on Elixir files
   elixir:format               Format Elixir files
+  elixir:format:lint          Check format on Elixir files
   elixir:lint                 Lint Elixir files
+  elixir:lint:light           Lint Elixir files without credo and formatter
   elixir:test                 Test Elixir files
   elixir:version              Show Elixir version
 
@@ -33,8 +36,27 @@ function elixir:lint {
     --only sobelow
 }
 
+# The checks below are performed on the whole project.
+# "lint-staged" passes file paths to "credo" and "formatter" which are excluded below.
+function elixir:lint:light {
+  mix check \
+    --only compiler \
+    --only dialyzer \
+    --only doctor \
+    --only unused_deps \
+    --only sobelow
+}
+
+function elixir:credo {
+  mix credo "${@}"
+}
+
 function elixir:format {
   mix format "${@}"
+}
+
+function elixir:format:lint {
+  mix format --check-formatted "${@}"
 }
 
 function elixir:test {


### PR DESCRIPTION
- Add `elixir:credo`
- Add `elixir:format:lint`
- Add `elixir:lint:light`
- Override `credo` and `formatter` with custom wrappers
- Do not run `lint-staged` in CI