### PR TITLE
chore: Exclude more directories in `.*ignore`, `credo` and `htmlhint`

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -19,14 +19,16 @@
         ],
         excluded: [
           ~r"/_build/",
+          ~r"/.elixir_ls/",
           ~r"/.git/",
           ~r"/.history/",
           ~r"/assets/",
+          ~r"/cover/",
           ~r"/deps/",
+          ~r"/doc/",
           ~r"/node_modules/",
           ~r"/npm_cache/",
-          ~r"/priv/",
-          ~r"/vendor/"
+          ~r"/priv/plts/"
         ]
       },
       checks: %{

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,6 @@
+# Git
+.git/
+
 # Local history (VSCode extension)
 .history/
 
@@ -17,3 +20,6 @@ doc/
 
 # ElixirLS (VSCode extension)
 .elixir_ls/
+
+# Dialyzer
+priv/plts/

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ config/*.secret.exs
 .elixir_ls/
 
 # Dialyzer
-**/priv/plts/
+priv/plts/
 
 # Sobelow
 .sobelow

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,6 @@
+# Git
+.git/
+
 # Local history (VSCode extension)
 .history/
 
@@ -18,3 +21,6 @@ doc/
 
 # ElixirLS (VSCode extension)
 .elixir_ls/
+
+# Dialyzer
+priv/plts/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
-vendor/
+# Git
+.git/
 
 # Local history (VSCode extension)
 .history/
@@ -25,6 +26,9 @@ doc/
 
 # ElixirLS (VSCode extension)
 .elixir_ls/
+
+# Dialyzer
+priv/plts/
 
 # see ./docs/setup.md in "Known issues" section
 *.eex

--- a/.prettierignore-eex
+++ b/.prettierignore-eex
@@ -1,4 +1,5 @@
-vendor/
+# Git
+.git/
 
 # Local history (VSCode extension)
 .history/
@@ -6,6 +7,15 @@ vendor/
 # NodeJS
 node_modules/
 npm_cache/
+
+# Cache for lints
+.eslintcache
+.stylelintcache
+.cspellcache
+
+# Text is generated automatically.
+# Also, as the file grows, it will take longer to lint and format.
+CHANGELOG.md
 
 # Elixir
 _build/
@@ -16,6 +26,9 @@ doc/
 
 # ElixirLS (VSCode extension)
 .elixir_ls/
+
+# Dialyzer
+priv/plts/
 
 # see ./docs/setup.md in "Known issues" section
 !*.eex

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,3 +1,6 @@
+# Git
+.git/
+
 # Local history (VSCode extension)
 .history/
 
@@ -14,3 +17,6 @@ doc/
 
 # ElixirLS (VSCode extension)
 .elixir_ls/
+
+# Dialyzer
+priv/plts/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   // Files:
   "files.associations": {
     ".prettierignore-eex": "ignore",
+    ".markdownlintignore": "ignore",
     ".sobelow-conf": "elixir",
     "**/.husky/*": "shellscript",
     "run": "shellscript"
@@ -29,8 +30,8 @@
     "**/deps/**": true,
     "**/doc/**": true,
     "**/erl_crash.dump": true,
-    "**/dialyzer.plt": true,
-    "**/dialyzer.plt.hash": true
+    // Dialyzer
+    "**/priv/plts": true
   },
   "files.exclude": {
     "**/.git": true,
@@ -55,8 +56,8 @@
     "**/deps": true,
     "**/doc": true,
     "**/erl_crash.dump": true,
-    "**/dialyzer.plt": true,
-    "**/dialyzer.plt.hash": true
+    // Dialyzer
+    "**/priv/plts": true
   },
 
   // Git:
@@ -75,6 +76,7 @@
   // Task explorer:
   "taskExplorer.groupSeparator": ":",
   "taskExplorer.exclude": [
+    "**/.git/**",
     "**/.history/**",
     // NodeJS
     "**/node_modules/**",
@@ -84,7 +86,10 @@
     "**/.elixir_ls/**",
     "**/.fetch/**",
     "**/cover/**",
-    "**/deps/**"
+    "**/deps/**",
+    "**/doc/**",
+    // Dialyzer
+    "**/priv/plts/**"
   ],
 
   // Comments:
@@ -238,14 +243,5 @@
       "extensions": [".prettierignore-eex"],
       "filename": true
     }
-  ],
-
-  // Code Spell Checker:
-  "cSpell.ignorePaths": [
-    "**/package-lock.json/**",
-    "**/node_modules/**",
-    "**/vscode-extension/**",
-    "**/.git/objects",
-    "**/.vscode-insiders/**"
   ]
 }

--- a/scripts/run/html.sh
+++ b/scripts/run/html.sh
@@ -10,14 +10,17 @@ EOF
 
 function html:lint {
   local ignore_globs=(
-    **/.history/**
-    **/node_modules/**
-    **/npm_cache/**
     **/_build/**
+    **/.elixir_ls/**
+    **/.fetch/**
+    **/.git/**
+    **/.history/**
     **/cover/**
     **/deps/**
     **/doc/**
-    **/.fetch/**
+    **/node_modules/**
+    **/npm_cache/**
+    **/priv/plts/**
   )
 
   local ignore_string="${ignore_globs[*]}"


### PR DESCRIPTION
- Ignore `.git`, `node_modules`, `npm_cache` and `priv/plts`
- Set `.markdownlintignore` as `ignore` file type