### PR TITLE
ci: Rename `PAT_PR_AUTO_MERGE` to `PAT_GITHUB`

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Mark PR to be automatically merged
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.PAT_PR_AUTO_MERGE }}
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
         run: |
           gh pr merge --auto --squash --delete-branch "$PR_URL"

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Update license year
         uses: FantasticFiasco/action-update-license-year@v2.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_GITHUB }}
           prTitle: "docs(license): Update copyright year to {{currentYear}}"
           commitTitle: "docs(license): Update copyright year to {{currentYear}}"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bash ./scripts/rename_project.sh [PROJECT_NAME] [OWNER_NAME]
 
 - [Create a Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
   with all scopes for `repo` checked
-- Add a new action secret named `PAT_PR_AUTO_MERGE` with the value of the PAT
+- Add a new action secret named `PAT_GITHUB` with the value of the PAT
 
 ## License
 


### PR DESCRIPTION
- Use `PAT_GITHUB` for workflow to update license year