### PR TITLE
chore(lint): Remove `eslint` specific rules which were not applied

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,9 +1,9 @@
 env:
   browser: true
-  es2021: true
+  es2022: true
 
 parserOptions:
-  ecmaVersion: 12
+  ecmaVersion: "latest"
   sourceType: module
 
 reportUnusedDisableDirectives: true
@@ -31,19 +31,7 @@ rules: {
     # Core rules
     no-warning-comments: error,
     # Plugin rules
-    import/no-extraneous-dependencies:
-      [
-        error,
-        { devDependencies: ["./scripts/**/*.{js,cjs}", .release-it.cjs] },
-      ],
     prefer-object-spread/prefer-object-spread: error,
     switch-case/newline-between-switch-case:
       [error, always, { fallthrough: never }],
   }
-
-overrides:
-  - files:
-      - ./scripts/**/*.{js,cjs}
-      - .release-it.js
-    rules:
-      unicorn/prefer-module: off

--- a/scripts/release-it/plugins/calver-bumper.js
+++ b/scripts/release-it/plugins/calver-bumper.js
@@ -8,6 +8,7 @@
  * Inspired from on https://github.com/release-it/conventional-changelog/blob/5.0.0/index.js
  */
 
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 import calver from 'calver';
 // eslint-disable-next-line import/no-unresolved
 import { Plugin } from 'release-it';


### PR DESCRIPTION
- Allow `calver` as `devDependencies`
- Update parser to latest version