### PR TITLE
chore(scripts): Reorder script names

### DIFF
--- a/.check.exs
+++ b/.check.exs
@@ -6,7 +6,7 @@
     # —————————————————————————————————————————————— #
     #       Extends curated tools from ex_check      #
     # —————————————————————————————————————————————— #
-    {:credo, "./run elixir:credo", detect: [{:package, :credo}]},
+    {:credo, "./run lint:elixir:credo", detect: [{:package, :credo}]},
     {:dialyzer, "mix dialyzer --format short", detect: [{:package, :dialyxir}]},
     {
       :doctor,
@@ -16,8 +16,8 @@
         {:elixir, ">= 1.8.0"}
       ]
     },
-    {:formatter, "./run elixir:format:lint",
-     detect: [{:file, ".formatter.exs"}], fix: "./run elixir:format"},
+    {:formatter, "./run lint:elixir:format",
+     detect: [{:file, ".formatter.exs"}], fix: "./run format:elixir"},
     {:npm_test, false},
     {
       :sobelow,
@@ -31,16 +31,16 @@
     # —————————————————————————————————————————————— #
     #                  Custom tools                  #
     # —————————————————————————————————————————————— #
-    {:css_lint, "./run css:lint"},
-    {:dockerfile_lint, "./run dockerfile:lint"},
-    {:elixir_eex_lint, "./run elixir:eex:lint"},
-    {:html_lint, "./run html:lint"},
-    {:js_lint, "./run js:lint"},
-    {:lint_staged, "./run lint-staged"},
-    {:markdown_lint, "./run markdown:lint"},
-    {:prettier_lint, "./run prettier:lint"},
-    {:release_test, "./run release:test"},
-    {:shell_lint, "./run shell:lint"},
-    {:spellcheck_lint, "./run spellcheck:lint"}
+    {:lint_css, "./run lint:css"},
+    {:lint_dockerfile, "./run lint:dockerfile"},
+    {:lint_elixir_eex, "./run lint:eex"},
+    {:lint_html, "./run lint:html"},
+    {:lint_js, "./run lint:js"},
+    {:lint_staged, "./run lint:staged"},
+    {:lint_markdown, "./run lint:markdown"},
+    {:lint_prettier, "./run lint:prettier"},
+    {:lint_shell, "./run lint:shell"},
+    {:lint_spellcheck, "./run lint:spellcheck"},
+    {:test_release, "./run test:release"}
   ]
 ]

--- a/.check_ci.exs
+++ b/.check_ci.exs
@@ -11,7 +11,7 @@
       ],
       retry: "mix coveralls.json --failed"
     },
-    {:git_commit_lint, "./run git:commit:lint"},
+    {:lint_git_commit, "./run lint:git:commit"},
     {:lint_staged, false}
   ]
 ]

--- a/.check_format.exs
+++ b/.check_format.exs
@@ -2,12 +2,12 @@
 [
   tools: [
     # Custom tools
-    {:css_format, "./run css:format"},
-    {:dockerfile_format, "./run dockerfile:format"},
-    {:elixir_format, "./run elixir:format"},
-    {:elixir_eex_format, "./run elixir:eex:format", deps: [:css_format, :js_format]},
-    {:js_format, "./run js:format"},
-    {:prettier_format, "./run prettier:format", deps: [:css_format, :js_format]},
-    {:shell_format, "./run shell:format"}
+    {:format_css, "./run format:css"},
+    {:format_dockerfile, "./run format:dockerfile"},
+    {:format_eex, "./run format:eex", deps: [:format_css, :format_js]},
+    {:format_elixir, "./run format:elixir"},
+    {:format_js, "./run format:js"},
+    {:format_prettier, "./run format:prettier", deps: [:format_css, :format_js]},
+    {:format_shell, "./run format:shell"}
   ]
 ]

--- a/.devcontainer/setup-dev-env.sh
+++ b/.devcontainer/setup-dev-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-./run install-deps
+./run install:deps
 
 cat <<EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
         id: versions
         run: |
           echo "::set-output name=node::$(./run --dc-ci dc:exec npm -v)"
-          echo "::set-output name=elixir::$(./run --dc-ci dc:exec ./run elixir:version)"
-          echo "::set-output name=erlang::$(./run --dc-ci dc:exec ./run erlang:version)"
+          echo "::set-output name=elixir::$(./run --dc-ci dc:exec ./run version:elixir)"
+          echo "::set-output name=erlang::$(./run --dc-ci dc:exec ./run version:erlang)"
 
       # —————————————————————————————————————————————— #
       #                      Cache                     #
@@ -155,27 +155,27 @@ jobs:
         run: |
           npm run prepare
 
-      - name: Set check flag for git:commit:lint
+      - name: Set check flag for lint:git:commit
         id: git-commit-lint
         run: |
           is_contributor_dependabot=false
 
-          run_git_commit_lint=false
+          run_lint_git_commit=false
 
-          if ./run git:commit:is-contributor-dependabot; then is_contributor_dependabot=true; fi
+          if ./run is-contributor-dependabot:git:commit; then is_contributor_dependabot=true; fi
 
           if [[ github.actor != "dependabot[bot]" && $is_contributor_dependabot = false ]]; then
-            run_git_commit_lint=true;
+            run_lint_git_commit=true;
           fi
 
-          echo "::set-output name=flag::$run_git_commit_lint"
+          echo "::set-output name=flag::$run_lint_git_commit"
 
       - name: Compile Elixir application and run all checks
         run: |
           except_opts=
 
           if [[ ${{ steps.git-commit-lint.outputs.flag }} = false ]]; then
-            except_opts="--except git_commit_lint"
+            except_opts="--except lint_git_commit"
           fi
 
           ./run --dc-ci dc:exec mix check.ci $except_opts

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,12 +10,12 @@ if [ "${CI:-false}" = false ] && [ "$branch" = "main" ]; then
 fi
 
 if [ -n "$RELEASE" ]; then
-  ./run lint-staged
+  ./run lint:staged
 elif [ -n "$INSIDE_DOCKER" ]; then
   ./run pre-commit
 else
   ./run --dc-dev dc:build
   ./run --dc-dev dc:up
-  ./run --dc-dev dc:exec ./run install-deps
+  ./run --dc-dev dc:exec ./run install:deps
   ./run --dc-dev dc:exec ./run pre-commit
 fi

--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,41 +1,41 @@
 "*":
-  - ./run spellcheck:lint
+  - ./run lint:spellcheck
 
 "*.{ex,exs}":
-  - ./run elixir:credo
-  - ./run elixir:format:lint
+  - ./run lint:elixir:credo
+  - ./run lint:elixir:format
 
 # HACK: "fake1" is a workaround to run different Elixir checks in parallel
 # https://github.com/okonet/lint-staged/issues/934#issuecomment-743299357
 "*.{ex,exs,fake1}":
-  - ./run elixir:lint:light
+  - ./run lint:elixir:light
 
 "*.{css,less,sass,scss}":
-  - ./run css:lint
-  - ./run prettier:lint
+  - ./run lint:css
+  - ./run lint:prettier
 
 "*.{htm,html}":
-  - ./run html:lint
-  - ./run prettier:lint
+  - ./run lint:html
+  - ./run lint:prettier
 
 "*.js":
-  - ./run js:lint
-  - ./run prettier:lint
+  - ./run lint:js
+  - ./run lint:prettier
 
 "*.html.{eex,leex}":
-  - ./run elixir:eex:lint
+  - ./run lint:eex
 
 "{run,.husky/*,*.sh}":
-  - ./run shell:lint
+  - ./run lint:shell
 
 "Dockerfile*":
-  - ./run dockerfile:lint
+  - ./run lint:dockerfile
 
 "*.{json,yaml,yml,htmlhintrc}":
-  - ./run prettier:lint
+  - ./run lint:prettier
 
 # CHANGELOG.md text is generated automatically.
 # Also, as the file grows, it will take longer to lint and format.
 "!(CHANGELOG).md":
-  - ./run prettier:lint
-  - ./run markdown:lint
+  - ./run lint:prettier
+  - ./run lint:markdown

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,10 +13,10 @@
       "detail": "Format code of the whole project"
     },
     {
-      "label": "install-deps",
+      "label": "install:deps",
       "type": "shell",
       "command": "./run",
-      "args": ["install-deps"],
+      "args": ["install:deps"],
       "problemMatcher": [],
       "detail": "Install all dependencies"
     },
@@ -29,10 +29,10 @@
       "detail": "Lint the whole project"
     },
     {
-      "label": "lint-staged",
+      "label": "lint:staged",
       "type": "shell",
       "command": "./run",
-      "args": ["lint-staged"],
+      "args": ["lint:staged"],
       "problemMatcher": [],
       "detail": "Lint staged files"
     },
@@ -94,37 +94,37 @@
     /*                    Elixir                    */
     /* ———————————————————————————————————————————— */
     {
-      "label": "elixir:format",
+      "label": "format:elixir",
       "type": "shell",
       "command": "./run",
-      "args": ["elixir:format"],
+      "args": ["format:elixir"],
       "problemMatcher": [],
       "detail": "Format Elixir files"
     },
     {
-      "label": "elixir:lint",
+      "label": "lint:elixir",
       "type": "shell",
       "command": "./run",
-      "args": ["elixir:lint"],
+      "args": ["lint:elixir"],
       "problemMatcher": [],
       "detail": "Lint Elixir files"
     },
     /* ———————————————————————————————————————————— */
-    /*                  Elixir EEx                  */
+    /*                      EEx                     */
     /* ———————————————————————————————————————————— */
     {
-      "label": "elixir:eex:format",
+      "label": "format:eex",
       "type": "shell",
       "command": "./run",
-      "args": ["elixir:eex:format"],
+      "args": ["format:eex"],
       "problemMatcher": [],
       "detail": "Format Embedded Elixir files"
     },
     {
-      "label": "elixir:eex:lint",
+      "label": "lint:eex",
       "type": "shell",
       "command": "./run",
-      "args": ["elixir:eex:lint"],
+      "args": ["lint:eex"],
       "problemMatcher": [],
       "detail": "Lint Embedded Elixir files"
     },
@@ -132,18 +132,18 @@
     /*                     Shell                    */
     /* ———————————————————————————————————————————— */
     {
-      "label": "shell:format",
+      "label": "format:shell",
       "type": "shell",
       "command": "./run",
-      "args": ["shell:format"],
+      "args": ["format:shell"],
       "problemMatcher": [],
       "detail": "Format Shell scripts"
     },
     {
-      "label": "shell:lint",
+      "label": "lint:shell",
       "type": "shell",
       "command": "./run",
-      "args": ["shell:lint"],
+      "args": ["lint:shell"],
       "problemMatcher": [],
       "detail": "Lint Shell scripts"
     },
@@ -151,18 +151,18 @@
     /*                  Dockerfile                  */
     /* ———————————————————————————————————————————— */
     {
-      "label": "dockerfile:format",
+      "label": "format:dockerfile",
       "type": "shell",
       "command": "./run",
-      "args": ["dockerfile:format"],
+      "args": ["format:dockerfile"],
       "problemMatcher": [],
       "detail": "Format all Dockerfiles"
     },
     {
-      "label": "dockerfile:lint",
+      "label": "lint:dockerfile",
       "type": "shell",
       "command": "./run",
-      "args": ["dockerfile:lint"],
+      "args": ["lint:dockerfile"],
       "problemMatcher": [],
       "detail": "Lint all Dockerfiles"
     },
@@ -170,10 +170,10 @@
     /*                      Git                     */
     /* ———————————————————————————————————————————— */
     {
-      "label": "git:commit:lint",
+      "label": "lint:git:commit",
       "type": "shell",
       "command": "./run",
-      "args": ["git:commit:lint"],
+      "args": ["lint:git:commit"],
       "problemMatcher": [],
       "detail": "Lint git commit message"
     },
@@ -181,10 +181,10 @@
     /*                   Markdown                   */
     /* ———————————————————————————————————————————— */
     {
-      "label": "markdown:lint",
+      "label": "lint:markdown",
       "type": "shell",
       "command": "./run",
-      "args": ["markdown:lint"],
+      "args": ["lint:markdown"],
       "problemMatcher": [],
       "detail": "Lint markdown files"
     },
@@ -192,18 +192,18 @@
     /*                   Prettier                   */
     /* ———————————————————————————————————————————— */
     {
-      "label": "prettier:format",
+      "label": "format:prettier",
       "type": "shell",
       "command": "./run",
-      "args": ["prettier:format"],
+      "args": ["format:prettier"],
       "problemMatcher": [],
       "detail": "Format files handled by Prettier"
     },
     {
-      "label": "prettier:lint",
+      "label": "lint:prettier",
       "type": "shell",
       "command": "./run",
-      "args": ["prettier:lint"],
+      "args": ["lint:prettier"],
       "problemMatcher": [],
       "detail": "Lint files handled by Prettier"
     },
@@ -211,18 +211,18 @@
     /*             CSS, SCSS, SASS, LESS            */
     /* ———————————————————————————————————————————— */
     {
-      "label": "css:format",
+      "label": "format:css",
       "type": "shell",
       "command": "./run",
-      "args": ["css:format "],
+      "args": ["format:css "],
       "problemMatcher": [],
       "detail": "Format CSS, SCSS, SASS, LESS and any files containing CSS"
     },
     {
-      "label": "css:lint",
+      "label": "lint:css",
       "type": "shell",
       "command": "./run",
-      "args": ["css:lint "],
+      "args": ["lint:css "],
       "problemMatcher": [],
       "detail": "Lint CSS, SCSS, SASS, LESS and any files containing CSS"
     },
@@ -230,10 +230,10 @@
     /*                     HTML                     */
     /* ———————————————————————————————————————————— */
     {
-      "label": "html:lint",
+      "label": "lint:html",
       "type": "shell",
       "command": "./run",
-      "args": ["html:lint"],
+      "args": ["lint:html"],
       "problemMatcher": [],
       "detail": "Lint HTML files and templates"
     },
@@ -241,18 +241,18 @@
     /*                  Javascript                  */
     /* ———————————————————————————————————————————— */
     {
-      "label": "js:format",
+      "label": "format:js",
       "type": "shell",
       "command": "./run",
-      "args": ["js:format"],
+      "args": ["format:js"],
       "problemMatcher": [],
       "detail": "Format JS files and any files containing Javascript"
     },
     {
-      "label": "js:lint",
+      "label": "lint:js",
       "type": "shell",
       "command": "./run",
-      "args": ["js:lint"],
+      "args": ["lint:js"],
       "problemMatcher": [],
       "detail": "Lint JS files and any files containing Javascript"
     }

--- a/cspell.yml
+++ b/cspell.yml
@@ -13,7 +13,7 @@ enableFiletypes:
 dictionaries:
   - abbreviations
   - binaries
-  - elixir-for-workspace
+  - elixir-custom
   - filenames
   - npm-packages
   - repo-owners
@@ -34,8 +34,8 @@ dictionaryDefinitions:
   - name: docker
     path: ./spellcheck/dictionaries/docker.txt
     addWords: true
-  - name: elixir-for-workspace
-    path: "./spellcheck/dictionaries/elixir-for-workspace.txt"
+  - name: elixir-custom
+    path: "./spellcheck/dictionaries/elixir-custom.txt"
     addWords: true
   - name: filenames
     path: ./spellcheck/dictionaries/filenames.txt
@@ -69,7 +69,7 @@ languageSettings:
   - languageId: elixir
     dictionaries:
       - elixir
-      - elixir-for-workspace
+      - elixir-custom
 
 overrides:
   - filename: "{run,.husky/*}"

--- a/docs/code-convention.md
+++ b/docs/code-convention.md
@@ -20,13 +20,15 @@ To help you to choose the right `type` or `scope`, you can commit:
 
 ### Function names
 
+- Format as following: `[purpose]:[scope]` where it may have multiple sub-scopes
+  separated by `:`
 - Use `:` to separate scopes
 - Use `-` (kebab-case) for scope names or purposes
 - Use `_` (snake_case) for helper functions that should not directly be used by
   the CLI
 
 ```shellscript
-function dev:dotnet-core:global-install {
+function install:dev:dotnet-core:global {
   ...
 }
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,13 +11,13 @@
 1. Install the extension `ms-vscode-remote.remote-containers`.
 1. `Ctrl+Shift+P` and choose `Remote-Containers: Open Folder in Container...`
 1. Wait container to be built (it takes a while).
-1. Run `./run install-deps` to install all dependencies.
+1. Run `./run install:deps` to install all dependencies.
 1. Run `./run help` to see all commands for this project.
 
 ### Development without VSCode
 
 1. Run `./run --dc-dev dc:console` to enter the container.
-1. Run `./run install-deps` to install all dependencies.
+1. Run `./run install:deps` to install all dependencies.
 1. Run `./run help` to see all commands for this project.
 
 ## UID and GID inside the container
@@ -38,7 +38,7 @@ description of `remoteUser` and `updateRemoteUserUID` on this [page](https://cod
 
    **Answer**: `prettier-plugin-eex` supports `prettier` up to `2.2.x` only.
 
-   **Temporary solution**: Run `./run elixir:eex:format` to format all `*.eex` files.
+   **Temporary solution**: Run `./run format:eex` to format all `*.eex` files.
    ([more info](https://github.com/adamzapasnik/prettier-plugin-eex/issues/51))
 
    For this reason, two versions of `prettier` are installed with two `.prettierignore`:

--- a/mix.exs
+++ b/mix.exs
@@ -40,13 +40,13 @@ defmodule App.MixProject do
       "check.ci": ["check --config .check_ci.exs"],
       "format.all": [
         "check --config .check_format.exs \
-          --only css_format \
-          --only dockerfile_format \
-          --only elixir_format \
-          --only elixir_eex_format \
-          --only js_format \
-          --only prettier_format \
-          --only shell_format \
+          --only format_css \
+          --only format_dockerfile \
+          --only format_elixir \
+          --only format_eex \
+          --only format_js \
+          --only format_prettier \
+          --only format_shell \
         "
       ],
       "npm.dev": ["cmd npm ci --quiet"],

--- a/run
+++ b/run
@@ -35,9 +35,9 @@ Options:
 Main commands:
   help                        Print this message
   format                      Format code of the whole project
-  install-deps                Install all dependencies
+  install:deps                Install all dependencies
   lint                        Lint the whole project
-  lint-staged                 Lint staged files
+  lint:staged                 Lint staged files
   pre-commit                  Lint staged files and test the whole project
   test                        Test the whole project
 
@@ -49,17 +49,17 @@ docker compose commands:
   dc:up                       Starts all docker services
 EOF
 
-  release:help
-  elixir:help
-  css:help
-  html:help
-  js:help
-  markdown:help
-  prettier:help
-  shell:help
-  dockerfile:help
-  spellcheck:help
-  git:help
+  help:release
+  help:elixir
+  help:css
+  help:html
+  help:js
+  help:markdown
+  help:prettier
+  help:shell
+  help:dockerfile
+  help:spellcheck
+  help:git
 }
 
 # —————————————————————————————————————————————— #
@@ -98,7 +98,6 @@ function test {
 }
 
 function lint {
-  # shellcheck disable=SC2119
   if is_inside_docker; then
     mix check \
       --except ex_unit \
@@ -110,7 +109,6 @@ function lint {
 }
 
 function format {
-  # shellcheck disable=SC2119
   if is_inside_docker; then
     mix format.all
   else
@@ -128,17 +126,17 @@ function pre-commit {
   fi
 }
 
-function lint-staged {
+function lint:staged {
   npx lint-staged
 }
 
-function install-deps {
+function install:deps {
   if is_inside_docker; then
     mix setup.deps.dev
 
     success "✔ Dependencies installed"
   else
-    dc:exec ./run install-deps
+    dc:exec ./run install:deps
   fi
 }
 

--- a/scripts/run/css.sh
+++ b/scripts/run/css.sh
@@ -2,16 +2,16 @@
 
 css_globs="**/*.{css,less,sass,scss}"
 
-function css:help {
+function help:css {
   cat <<EOF
 
 CSS commands:
-  css:format                  Format CSS, SCSS, SASS, LESS and any files containing CSS
-  css:lint                    Lint CSS, SCSS, SASS, LESS and any files containing CSS
+  format:css                  Format CSS, SCSS, SASS, LESS and any files containing CSS
+  lint:css                    Lint CSS, SCSS, SASS, LESS and any files containing CSS
 EOF
 }
 
-function css:lint {
+function lint:css {
   npx stylelint \
     --allow-empty-input \
     --color \
@@ -19,7 +19,7 @@ function css:lint {
     "${@:-${css_globs}}"
 }
 
-function css:format {
+function format:css {
   npx stylelint \
     --fix \
     --allow-empty-input \

--- a/scripts/run/docker_file.sh
+++ b/scripts/run/docker_file.sh
@@ -2,19 +2,19 @@
 
 dockerfile_globs=(Dockerfile*)
 
-function dockerfile:help {
+function help:dockerfile {
   cat <<EOF
 
 Dockerfile commands:
-  dockerfile:format           Format all Dockerfiles
-  dockerfile:lint             Lint all Dockerfiles
+  format:dockerfile           Format all Dockerfiles
+  lint:dockerfile             Lint all Dockerfiles
 EOF
 }
 
-function dockerfile:lint {
+function lint:dockerfile {
   hadolint "${@:-${dockerfile_globs[@]}}"
 }
 
-function dockerfile:format {
+function format:dockerfile {
   shfmt -w "${@:-${dockerfile_globs[@]}}"
 }

--- a/scripts/run/elixir.sh
+++ b/scripts/run/elixir.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 
-function elixir:help {
+function help:elixir {
   cat <<EOF
 
 Elixir commands:
-  elixir:credo                Perform checks with Credo on Elixir files
-  elixir:format               Format Elixir files
-  elixir:format:lint          Check format on Elixir files
-  elixir:lint                 Lint Elixir files
-  elixir:lint:light           Lint Elixir files without credo and formatter
-  elixir:test                 Test Elixir files
-  elixir:version              Show Elixir version
+  format:elixir               Format Elixir files
+  lint:elixir:credo           Perform checks with Credo on Elixir files
+  lint:elixir:format          Check format on Elixir files
+  lint:elixir                 Lint Elixir files
+  lint:elixir:light           Lint Elixir files without credo and formatter
+  test:elixir                 Test Elixir files
+  version:elixir              Show Elixir version
 
-Elixir EEx commands:
-  elixir:eex:format           Format Embedded Elixir files
-  elixir:eex:lint             Lint Embedded Elixir files
+EEx commands:
+  format:eex           Format Embedded Elixir files
+  lint:eex             Lint Embedded Elixir files
 
 Erlang commands:
-  erlang:format               Show Erlang version
+  version:erlang               Show Erlang version
 EOF
 }
 
@@ -25,7 +25,7 @@ EOF
 #                     Elixir                     #
 # —————————————————————————————————————————————— #
 
-function elixir:lint {
+function lint:elixir {
   mix check \
     --only compiler \
     --only credo \
@@ -37,8 +37,8 @@ function elixir:lint {
 }
 
 # The checks below are performed on the whole project.
-# "lint-staged" passes file paths to "credo" and "formatter" which are excluded below.
-function elixir:lint:light {
+# "lint:staged" passes file paths to "credo" and "formatter" which are excluded below.
+function lint:elixir:light {
   mix check \
     --only compiler \
     --only dialyzer \
@@ -47,23 +47,23 @@ function elixir:lint:light {
     --only sobelow
 }
 
-function elixir:credo {
+function lint:elixir:credo {
   mix credo "${@}"
 }
 
-function elixir:format {
+function format:elixir {
   mix format "${@}"
 }
 
-function elixir:format:lint {
+function lint:elixir:format {
   mix format --check-formatted "${@}"
 }
 
-function elixir:test {
+function test:elixir {
   mix check --only ex_unit
 }
 
-function elixir:version {
+function version:elixir {
   mix run \
     --no-compile \
     --no-deps-check \
@@ -72,9 +72,8 @@ function elixir:version {
     --no-start \
     -e "IO.puts(System.version)"
 }
-
 # —————————————————————————————————————————————— #
-#                   Elixir EEx                   #
+#                       EEx                      #
 # —————————————————————————————————————————————— #
 
 # NOTE: Avoid error "No files matching the pattern were found" by adding prettierrc.yml
@@ -86,11 +85,11 @@ function prettier-eex {
     --ignore-path=./.prettierignore-eex "${@}"
 }
 
-function elixir:eex:lint {
+function lint:eex {
   prettier-eex --check "${@:-${eex_glob}}"
 }
 
-function elixir:eex:format {
+function format:eex {
   prettier-eex --list-different --write "${@:-${eex_glob}}"
 }
 
@@ -98,7 +97,7 @@ function elixir:eex:format {
 #                     Erlang                     #
 # —————————————————————————————————————————————— #
 
-function erlang:version {
+function version:erlang {
   erl -eval "{ok, Version} = file:read_file(filename:join([code:root_dir(), \
     'releases', erlang:system_info(otp_release), 'OTP_VERSION'])), \
     io:fwrite(Version), halt()." -noshell

--- a/scripts/run/git.sh
+++ b/scripts/run/git.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 
-function git:help {
+function help:git {
   cat <<EOF
 
 Git commands:
-  git:commit:lint                       Lint git commit message
-  git:commit:is-contributor-dependabot  Check if Dependabot is (co-)author of the commit
+  lint:git:commit                       Lint git commit message
+  is-contributor-dependabot:git:commit  Check if Dependabot is (co-)author of the commit
 EOF
 }
 
 # NOTE: Dependabot is not flexible to apply commitlint rules
 # see: https://github.com/dependabot/dependabot-core/issues/1666
 # see: https://github.com/dependabot/dependabot-core/issues/2056
-function git:commit:lint {
+function lint:git:commit {
   local commit_message
 
-  if git:commit:is-contributor-dependabot; then
+  if is-contributor-dependabot:git:commit; then
     warning "SKIPPED './run ${FUNCNAME[0]}': Dependabot is (co-)author of latest commit"
 
     close
@@ -26,7 +26,7 @@ function git:commit:lint {
   echo "${commit_message}" | npx commitlint --color
 }
 
-function git:commit:is-contributor-dependabot {
+function is-contributor-dependabot:git:commit {
   is_author_dependabot || is_co_author_dependabot
 }
 

--- a/scripts/run/html.sh
+++ b/scripts/run/html.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-function html:help {
+function help:html {
   cat <<EOF
 
 HTML commands:
-  html:lint                   Lint HTML files and templates
+  lint:html                   Lint HTML files and templates
 EOF
 }
 
-function html:lint {
+function lint:html {
   local ignore_globs=(
     **/_build/**
     **/.elixir_ls/**

--- a/scripts/run/javascript.sh
+++ b/scripts/run/javascript.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-function js:help {
+function help:js {
   cat <<EOF
 Javascript commands:
-  js:format                  Format JS files and any files containing Javascript
-  js:lint                    Lint JS files and any files containing Javascript
+  format:js                  Format JS files and any files containing Javascript
+  lint:js                    Lint JS files and any files containing Javascript
 EOF
 }
 
-function js:lint {
+function lint:js {
   npx eslint \
     --cache \
     --color \
@@ -18,7 +18,7 @@ function js:lint {
     "${@:-.}"
 }
 
-function js:format {
+function format:js {
   npx eslint \
     --fix \
     --fix-type layout \

--- a/scripts/run/markdown.sh
+++ b/scripts/run/markdown.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-function markdown:help {
+function help:markdown {
   cat <<EOF
 
 Markdown commands:
-  markdown:lint               Lint markdown files
+  lint:markdown               Lint markdown files
 EOF
 }
 
-function markdown:lint {
+function lint:markdown {
   npx markdownlint "${@:-.}"
 }

--- a/scripts/run/prettier.sh
+++ b/scripts/run/prettier.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-function prettier:help {
+function help:prettier {
   cat <<EOF
 
 Prettier commands:
-  prettier:format             Format files handled by Prettier
-  prettier:lint               Lint files handled by Prettier
+  format:prettier             Format files handled by Prettier
+  lint:prettier               Lint files handled by Prettier
 EOF
 }
 
-function prettier:lint {
+function lint:prettier {
   npx prettier --check "${@:-.}"
 }
 
-function prettier:format {
+function format:prettier {
   npx prettier --list-different --write "${@:-.}"
 }

--- a/scripts/run/release.sh
+++ b/scripts/run/release.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
-function release:help {
+function help:release {
   cat <<EOF
 
 Release commands:
   release                     Update CHANGELOG.md and version files, cut a release and publish to Github
   release:ci [MODIFIER]       Release from CI. If modifier given, it will prerelease.
   release:dry-run             Simulate cutting a release without updating files or pushing to git
-  release:test                Dry run release, run tests for release
   release:hooks:test          Run tests for hooks during a release
   prerelease                  Cut a prerelease, tag with a suffix it and publish it to Github (default: dev)
   - Usage: prerelease [dev|alpha|beta|rc]
   release-it:custom:test      Run tests related to custom hooks and/or plugins for release-it
+  test:release                Dry run release, run tests for release
 EOF
 }
 
@@ -38,7 +38,7 @@ function release:dry-run {
     --git.pushRepo="git://fake.host.for.dry.run:user/repo"
 }
 
-function release:test {
+function test:release {
   release-it:custom:test
   release:dry-run
   release:hooks:test

--- a/scripts/run/shell.sh
+++ b/scripts/run/shell.sh
@@ -9,19 +9,19 @@ shell_scripts_globs=(
   scripts/**/*.sh
 )
 
-function shell:help {
+function help:shell {
   cat <<EOF
 
 Shell commands:
-  shell:format                Format given Shell scripts
-  shell:lint                  Lint given Shell scripts
+  format:shell                Format given Shell scripts
+  lint:shell                  Lint given Shell scripts
 EOF
 }
 
-function shell:lint {
+function lint:shell {
   shellcheck -x "${@:-${shell_scripts_globs[@]}}"
 }
 
-function shell:format {
+function format:shell {
   shfmt -w "${@:-${shell_scripts_globs[@]}}"
 }

--- a/scripts/run/spellcheck.sh
+++ b/scripts/run/spellcheck.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-function spellcheck:help {
+function help:spellcheck {
   cat <<EOF
 
 Spellcheck commands:
-  spellcheck:lint             Run spellcheck
+  lint:spellcheck             Run spellcheck
 EOF
 }
 
-function spellcheck:lint {
+function lint:spellcheck {
   npx cspell lint \
     --cache \
     --color \

--- a/spellcheck/dictionaries/elixir-custom.txt
+++ b/spellcheck/dictionaries/elixir-custom.txt
@@ -5,6 +5,7 @@ eval
 excoveralls
 fwrite
 hexpm
+eex
 leex
 macrocallback
 noshell


### PR DESCRIPTION
- Script names are now as follow: [purpose]:[scope]
- Rename `install-deps` to `install:deps`
- Rename `lint-staged` to `lint:staged`
- Rename `elixir:eex` to `eex`
- Rename `elixir-for-workspace.txt` to `elixir-custom.txt`
- Reenable shellcheck SC2119
- Adapt documentation