### PR TITLE
chore(lint): Lint with credo and format Elixir templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             **/_build
             **/.sobelow
           key: |
-            ${{ runner.os }}-elixir-build-${{ steps.versions.outputs.ELIXIR }}-${{ steps.versions.outputs.ERLANG }}-${{ hashFiles('**/mix.lock') }}-${{ hashFiles( '**/lib/**/*.{ex,eex}', '**/config/*.exs', '**/mix.exs' ) }}
+            ${{ runner.os }}-elixir-build-${{ steps.versions.outputs.ELIXIR }}-${{ steps.versions.outputs.ERLANG }}-${{ hashFiles('**/mix.lock') }}-${{ hashFiles( '**/lib/**/*.{ex,eex,leex}', '**/config/*.exs', '**/mix.exs' ) }}
           restore-keys: |
             ${{ runner.os }}-elixir-build-${{ steps.versions.outputs.ELIXIR }}-${{ steps.versions.outputs.ERLANG }}-${{ hashFiles('**/mix.lock') }}-
             ${{ runner.os }}-elixir-build-${{ steps.versions.outputs.ELIXIR }}-${{ steps.versions.outputs.ERLANG }}-

--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,13 +1,13 @@
 "*":
   - ./run lint:spellcheck
 
-"*.{ex,exs}":
+"*.{ex,exs,eex,leex}":
   - ./run lint:elixir:credo
   - ./run lint:elixir:format
 
 # HACK: "fake1" is a workaround to run different Elixir checks in parallel
 # https://github.com/okonet/lint-staged/issues/934#issuecomment-743299357
-"*.{ex,exs,fake1}":
+"*.{ex,exs,eex,leex,fake1}":
   - ./run lint:elixir:light
 
 "*.{css,less,sass,scss}":


### PR DESCRIPTION
- In CI step for `Cache Elixir build`, `leex` are included in the key hash